### PR TITLE
added prettier formatting before commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
   - run:  | 
       cd $TARGET
       kustomize edit set image $IMAGE=:$TAG
+      npx prettier --write kustomization.yml
       cat kustomization.yml
     shell: bash
     env:


### PR DESCRIPTION
Node is already included in the default image the workflow uses. We can just add a command that runs prettier using `npx`, so we don't have to mess with installing it ourselves. 